### PR TITLE
fix: provide endpoint param to aminosigner class

### DIFF
--- a/networks/cosmjs/cosmwasm-stargate.ts
+++ b/networks/cosmjs/cosmwasm-stargate.ts
@@ -1,12 +1,13 @@
 import { AminoSigner } from "@uni-sign/cosmos/amino";
-import { StargateMsgs } from "@uni-sign/cosmos-msgs/stargate";
-import { CosmWasmMsgs } from "@uni-sign/cosmos-msgs/cosmwasm";
-import { TxImpl } from "@uni-sign/cosmos-msgs/stargate-cosmwasm.tx";
-import { SigningClient } from "./signing-client";
-import { OfflineSigner } from "./types/wallet";
-import { SignerOptions } from "./types/signing-client";
-import { HttpEndpoint } from "@uni-sign/types";
 import { toConverter, toEncoder } from "@uni-sign/cosmos/utils";
+import { CosmWasmMsgs } from "@uni-sign/cosmos-msgs/cosmwasm";
+import { StargateMsgs } from "@uni-sign/cosmos-msgs/stargate";
+import { TxImpl } from "@uni-sign/cosmos-msgs/stargate-cosmwasm.tx";
+import { HttpEndpoint } from "@uni-sign/types";
+
+import { SigningClient } from "./signing-client";
+import { SignerOptions } from "./types/signing-client";
+import { OfflineSigner } from "./types/wallet";
 import { defaultAuth } from "./utils";
 
 export class CosmWasmSigningClient extends SigningClient {
@@ -33,7 +34,7 @@ export class CosmWasmSigningClient extends SigningClient {
     signer: OfflineSigner,
     options: SignerOptions = {}
   ): CosmWasmSigningClient {
-    const aminoSigner = new AminoSigner(defaultAuth, [], []);
+    const aminoSigner = new AminoSigner(defaultAuth, [], [], endpoint);
     const signingClient = new CosmWasmSigningClient(
       aminoSigner,
       signer,

--- a/networks/cosmjs/signing-client.ts
+++ b/networks/cosmjs/signing-client.ts
@@ -1,6 +1,36 @@
+import { AminoSigner } from "@uni-sign/cosmos/amino";
+import {
+  Any,
+  AuthInfo,
+  IBinaryWriter,
+  Secp256k1PubKey,
+  SignDoc,
+  SignerInfo,
+  SignMode,
+  TxBody,
+  TxRaw,
+} from "@uni-sign/cosmos/types";
+import {
+  constructAuthInfo,
+  constructSignerInfo,
+  constructTxBody,
+  toAminoMsgs,
+  toEncoder,
+  toFee,
+  toMessages,
+} from "@uni-sign/cosmos/utils";
+import { TxRpc } from "@uni-sign/cosmos-msgs/types";
 import { Auth, HttpEndpoint, Price, StdFee, StdSignDoc } from "@uni-sign/types";
 import { fromBase64, Key } from "@uni-sign/utils";
 
+import {
+  Block,
+  BlockResponse,
+  IndexedTx,
+  SearchTxQuery,
+  SearchTxResponse,
+  TxResponse,
+} from "./types/query";
 import {
   DeliverTxResponse,
   EncodeObject,
@@ -13,37 +43,7 @@ import {
   OfflineDirectSigner,
   OfflineSigner,
 } from "./types/wallet";
-import { defaultAuth, BroadcastTxError, sleep, TimeoutError } from "./utils";
-import {
-  AuthInfo,
-  Secp256k1PubKey,
-  SignDoc,
-  SignMode,
-  SignerInfo,
-  TxBody,
-  TxRaw,
-  IBinaryWriter,
-  Any,
-} from "@uni-sign/cosmos/types";
-import {
-  constructAuthInfo,
-  constructSignerInfo,
-  constructTxBody,
-  toAminoMsgs,
-  toEncoder,
-  toFee,
-  toMessages,
-} from "@uni-sign/cosmos/utils";
-import { AminoSigner } from "@uni-sign/cosmos/amino";
-import {
-  SearchTxQuery,
-  SearchTxResponse,
-  IndexedTx,
-  Block,
-  BlockResponse,
-  TxResponse,
-} from "./types/query";
-import { TxRpc } from "@uni-sign/cosmos-msgs/types";
+import { BroadcastTxError, defaultAuth, sleep, TimeoutError } from "./utils";
 
 /**
  * implement the same methods as what in `cosmjs` signingClient
@@ -96,7 +96,7 @@ export class SigningClient {
     signer: OfflineSigner,
     options: SignerOptions = {}
   ): SigningClient {
-    const aminoSigner = new AminoSigner(defaultAuth, [], []);
+    const aminoSigner = new AminoSigner(defaultAuth, [], [], endpoint);
     const signingClient = new SigningClient(aminoSigner, signer, options);
     signingClient.setEndpoint(endpoint);
     return signingClient;

--- a/networks/cosmjs/stargate.ts
+++ b/networks/cosmjs/stargate.ts
@@ -1,11 +1,12 @@
 import { AminoSigner } from "@uni-sign/cosmos/amino";
+import { toConverter, toEncoder } from "@uni-sign/cosmos/utils";
 import { StargateMsgs } from "@uni-sign/cosmos-msgs/stargate";
 import { TxImpl } from "@uni-sign/cosmos-msgs/stargate.tx";
-import { SigningClient } from "./signing-client";
-import { OfflineSigner } from "./types/wallet";
-import { SignerOptions } from "./types/signing-client";
 import { HttpEndpoint } from "@uni-sign/types";
-import { toConverter, toEncoder } from "@uni-sign/cosmos/utils";
+
+import { SigningClient } from "./signing-client";
+import { SignerOptions } from "./types/signing-client";
+import { OfflineSigner } from "./types/wallet";
 import { defaultAuth } from "./utils";
 
 export class StargateSigningClient extends SigningClient {
@@ -28,7 +29,7 @@ export class StargateSigningClient extends SigningClient {
     signer: OfflineSigner,
     options: SignerOptions = {}
   ): StargateSigningClient {
-    const aminoSigner = new AminoSigner(defaultAuth, [], []);
+    const aminoSigner = new AminoSigner(defaultAuth, [], [], endpoint);
     const signingClient = new StargateSigningClient(
       aminoSigner,
       signer,


### PR DESCRIPTION
## Draft
The solution is still being tested locally

## Problem
When calling `signer.sign`
On file `signing-client.ts`
```
Uncaught Error: target is undefined
```
Apparently it might be because `queryClient` is not well defined

## Changes
- Automatic import sort update
- provide endpoint to AminoSigner()
```ts
const aminoSigner = new AminoSigner(defaultAuth, [], [], endpoint);
```

