### PR TITLE
chore: keplr method context & add dymension prefix

### DIFF
--- a/networks/cosmjs/signing-client.ts
+++ b/networks/cosmjs/signing-client.ts
@@ -124,7 +124,7 @@ export class SigningClient {
   }
 
   private async getAccountData(address: string): Promise<AccountData> {
-    const accounts = await this._getAccounts();
+    const accounts = await this.offlineSigner.getAccounts();
     const account = accounts.find((account) => account.address === address);
     if (!account) {
       throw new Error(

--- a/networks/cosmos/data/prefix.json
+++ b/networks/cosmos/data/prefix.json
@@ -55,6 +55,7 @@
   "devnet-1": "ixo",
   "dig-1": "dig",
   "dimension_37-1": "xpla",
+  "dymension_1100-1": "dym",
   "dorado-1": "fetch",
   "dyson-mainnet-01": "dys",
   "echelon_3000-3": "echelon",


### PR DESCRIPTION
## Wrong this context
- The assignation of keplr methods with "this" causes context issues, this becomes the wrong signer, and doesnt have chainId attribute
Reference: https://github.com/cosmology-tech/uni-sign/blob/main/networks/cosmjs/signing-client.ts#L127
calling `offlineSigner.getAccounts()` instead of `this._getAccounts()` solves this

## Add dymension chain prefix
- adds Dymension chain prefix in prefix.json